### PR TITLE
fallback to pytesseract for local

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ https://github.com/user-attachments/assets/aa053824-b0c3-46b8-9ca5-8067e8b85482
 
 1. It is tested on `Python 3.12` so install that first
 2. Install [`PyAudio`](https://pypi.org/project/PyAudio/) for your system (it is tested on Mac so should work for linux too. Not sure about Windows)
-3. Get you [OpenAI API Key](https://medium.com/@lorenzozar/how-to-get-your-own-openai-api-key-f4d44e60c327)
-4. Clone this repo or download the zip file
-5. Open Terminal and navigate to the location which contains `requirements.txt`
-6. Install requirements using `pip install -r requirements.txt`
+3. For local OCR using `pytesseract` **(Recommended)**, install [Tesseract Engine](https://tesseract-ocr.github.io/tessdoc/Installation.html)
+4. Get you [OpenAI API Key](https://medium.com/@lorenzozar/how-to-get-your-own-openai-api-key-f4d44e60c327)
+5. Clone this repo or download the zip file
+6. Open Terminal and navigate to the location which contains `requirements.txt`
+7. Install requirements using `pip install -r requirements.txt`
 
 ## What if you don't have GPU?
 1. Upload `Colab_Transcription.ipynb` to Colab

--- a/fastapi_app/config.json
+++ b/fastapi_app/config.json
@@ -14,7 +14,11 @@
     },
 
     "transcription": {
-      "num_speakers": 1,
-      "CLOUD_API_ENDPOINT": "https://59c0-34-169-92-72.ngrok-free.app"
+      "num_speakers": 1
+    },
+    
+    "CLOUD_APIS": {
+      "TRANSCRIPTION_API_ENDPOINT": "https://e7f3-34-72-73-211.ngrok-free.app", 
+      "OCR_API_ENDPOINT": ""
     }
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ PyAudio==0.2.14
 pydantic==2.5.0
 pydantic_core==2.14.1
 PyAutoGUI==0.9.54
+pytesseract==0.3.13
 tiktoken==0.7.0
 torch==2.5.0
 torchaudio==2.5.0


### PR DESCRIPTION
Use tesseract for local screenshot which is faster way to do things. It saves up memory. Will implement the same in cloud instead of other one. That one is heavy >10GB GPU and we can use that one for our embedding and RAG